### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/massgov/masstexts-d8-ic.png?label=ready&title=Ready)](https://waffle.io/massgov/masstexts-d8-ic)
 # MassText - alpha D8 build
 [![Build Status](https://travis-ci.org/isaacchansky/drupal-starter.svg?branch=master)](https://travis-ci.org/isaacchansky/drupal-starter)
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/massgov/masstexts-d8-ic

This was requested by a real person (user isaacchansky) on waffle.io, we're not trying to spam you.